### PR TITLE
Correct scrolling behaviour when content updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Console panel
 
-[![Build status](https://ci.appveyor.com/api/projects/status/biwxyu9p0cwjl5r1/branch/master?svg=true)](https://ci.appveyor.com/project/reupen/console-panel/branch/master)
+[![Build status](https://reupen.visualstudio.com/Columns%20UI/_apis/build/status/reupen.console_panel?branchName=master)](https://reupen.visualstudio.com/Columns%20UI/_build/latest?definitionId=5&branchName=master)
 
 Console panel for Columns UI.

--- a/foo_uie_console/main.cpp
+++ b/foo_uie_console/main.cpp
@@ -208,7 +208,7 @@ void ConsoleWindow::update_content()
     }
     uSetWindowText(m_wnd_edit, buffer);
     const int len = Edit_GetLineCount(m_wnd_edit);
-    Edit_Scroll(m_wnd_edit, 0, len);
+    Edit_Scroll(m_wnd_edit, len, 0);
     QueryPerformanceCounter(&m_time_last_update);
 }
 


### PR DESCRIPTION
This fixes a regression in bf8c7d1 where the edit box would be scrolled to the top whenever a new console message was logged.

