### PR TITLE
Don't destroy window when pressing Esc if contained in a dialog

### DIFF
--- a/foo_uie_console/main.cpp
+++ b/foo_uie_console/main.cpp
@@ -434,7 +434,8 @@ LRESULT ConsoleWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             SendMessage(wnd, MSG_UPDATE, 0, 0);
         }
-    } break;
+        break;
+    }
     case WM_TIMER:
         if (wp == ID_TIMER) {
             KillTimer(wnd, ID_TIMER);
@@ -463,6 +464,8 @@ LRESULT ConsoleWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
     case WM_ERASEBKGND:
         return FALSE;
+    case WM_CLOSE:
+        return 0;
     case WM_DESTROY:
         m_wnd_edit = nullptr;
         s_windows.erase(std::remove(s_windows.begin(), s_windows.end(), this), s_windows.end());


### PR DESCRIPTION
This resolves a problem where, when the Console panel is contained within a dialog e.g. using the Popup Panels component, pressing Esc causes the console child window to be destroyed (leaving an empty space where it was).

The reason this was happening was [described by Raymond Chen in a post in 1999](https://archive.ph/Ucvk7):

> Yes, when you hit ESC in a multiline edit, it posts a WM_CLOSE to
> its parent in the mistaken belief that it is part of a dialog
> box. This is for compatibility with Windows 2.0, which behaved
> this way. It's annoying now, but compatibility means having to
> be bug-for-bug compatible with the previous version...