### PR TITLE
Stop edit control scrolling up when changing font

### DIFF
--- a/foo_uie_console/main.cpp
+++ b/foo_uie_console/main.cpp
@@ -48,13 +48,7 @@ constexpr auto current_config_version = 0;
 
 void ConsoleWindow::s_update_all_fonts()
 {
-    if (s_font) {
-        for (auto&& window : s_windows) {
-            if (const HWND wnd = window->m_wnd_edit)
-                SetWindowFont(wnd, nullptr, FALSE);
-        }
-    }
-
+    const auto old_font = std::move(s_font);
     s_font.reset(cui::fonts::helper(console_font_id).get_font());
 
     for (auto&& window : s_windows) {


### PR DESCRIPTION
This fixes a problem where the edit control would scroll up when changing the font at high display scales.

This was because the font was being set to `nullptr` before being set to the new font, causing the System bitmap font to be temporarily used.