### PR TITLE
Format times using user’s locale

### DIFF
--- a/foo_uie_console/foo_uie_console.vcxproj
+++ b/foo_uie_console/foo_uie_console.vcxproj
@@ -45,24 +45,28 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-test|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-test|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -358,14 +362,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
@@ -407,14 +408,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
@@ -443,14 +441,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
@@ -490,14 +485,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>

--- a/foo_uie_console/main.h
+++ b/foo_uie_console/main.h
@@ -5,8 +5,11 @@
 #include <algorithm>
 #include <chrono>
 #include <deque>
+#include <locale>
 #include <mutex>
 #include <vector>
+
+#include <fmt/xchar.h>
 
 #include "../ui_helpers/stdafx.h"
 
@@ -39,9 +42,9 @@ enum class EdgeStyle : int {
 class Message {
 public:
     std::chrono::system_clock::time_point m_timestamp;
-    std::string m_message;
+    std::wstring m_message;
 
-    Message(std::string message) : m_timestamp(std::chrono::system_clock::now()), m_message(std::move(message)) {}
+    Message(std::wstring message) : m_timestamp(std::chrono::system_clock::now()), m_message(std::move(message)) {}
 };
 
 class ConsoleWindow : public uie::container_uie_window_v3 {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -20,14 +20,14 @@ auto normalise_message(std::string_view text) {
 }
 
 TEST_CASE("normalises message line endings") {
-  CHECK(normalise_message("Test"sv) == "Test"sv);
-  CHECK(normalise_message("Test\r"sv) == "Test"sv);
-  CHECK(normalise_message("Test\n"sv) == "Test"sv);
-  CHECK(normalise_message("Test\r\n"sv) == "Test"sv);
-  CHECK(normalise_message("Test\rTest"sv) == "TestTest"sv);
-  CHECK(normalise_message("Test\nTest"sv) == "Test\r\nTest"sv);
-  CHECK(normalise_message("Test\r\nTest"sv) == "Test\r\nTest"sv);
-  CHECK(normalise_message("Test\r\rTest"sv) == "TestTest"sv);
-  CHECK(normalise_message("Test\n\nTest"sv) == "Test\r\n\r\nTest"sv);
-  CHECK(normalise_message("Test\r\n\r\nTest"sv) == "Test\r\n\r\nTest"sv);
+  CHECK(normalise_message("Test"sv) == L"Test"sv);
+  CHECK(normalise_message("Test\r"sv) == L"Test"sv);
+  CHECK(normalise_message("Test\n"sv) == L"Test"sv);
+  CHECK(normalise_message("Test\r\n"sv) == L"Test"sv);
+  CHECK(normalise_message("Test\rTest"sv) == L"TestTest"sv);
+  CHECK(normalise_message("Test\nTest"sv) == L"Test\r\nTest"sv);
+  CHECK(normalise_message("Test\r\nTest"sv) == L"Test\r\nTest"sv);
+  CHECK(normalise_message("Test\r\rTest"sv) == L"TestTest"sv);
+  CHECK(normalise_message("Test\n\nTest"sv) == L"Test\r\n\r\nTest"sv);
+  CHECK(normalise_message("Test\r\n\r\nTest"sv) == L"Test\r\n\r\nTest"sv);
 }


### PR DESCRIPTION
This amends the time formatting to use the user’s locale (which should reflect the regional date and time formats configured in Windows).

It also fixes a regression in #280 that caused the time to be shown in UTC.

Lastly, some problems with the debug project configuration were fixed.