### PR TITLE
Update dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "console-panel",
   "version-string": "git",
-  "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+  "builtin-baseline": "927f62e4b8838bd7e441e9c45103a16ffd75007e",
   "dependencies": [
     "fmt",
     "foonathan-lexy",
@@ -13,7 +13,7 @@
   "overrides": [
     {
       "name": "doctest",
-      "version": "2.4.12"
+      "version": "2.5.2"
     },
     {
       "name": "fmt",
@@ -25,7 +25,7 @@
     },
     {
       "name": "ms-gsl",
-      "version": "4.2.0"
+      "version": "4.2.2"
     },
     {
       "name": "range-v3",
@@ -33,7 +33,7 @@
     },
     {
       "name": "wil",
-      "version": "1.0.250325.1"
+      "version": "1.0.260126.7"
     }
   ]
 }


### PR DESCRIPTION
This updates GSL, WIL and doctest to the latest versions.

In particular, GSL 4.2.2 fixes a compiler warning that occurred with the latest VS 2026 toolset.